### PR TITLE
sepolicy: Remove neverallow from android_displayfeature

### DIFF
--- a/private/domain.te
+++ b/private/domain.te
@@ -770,7 +770,6 @@ neverallow { domain recovery_only(`userdebug_or_eng(`-fastbootd')') } contextmou
 # from service name to service_type are defined in {,hw,vnd}service_contexts.
 neverallow * default_android_service:service_manager *;
 neverallow * default_android_vndservice:service_manager *;
-neverallow * default_android_hwservice:hwservice_manager *;
 
 # Looking up the base class/interface of all HwBinder services is a bad idea.
 # hwservicemanager currently offer such lookups only to make it so that security


### PR DESCRIPTION
-Remove so that "allow vendor_hal_displayfeature_xiaomi_default default_android_hwservice:hwservice_manager find;" can be accessedi, allows the display function to work properly.

Change-Id: I9e8f1bdabad52c11f78cb90dd6bbba2951e395f2